### PR TITLE
PLATFORM-2827 updating identity java client and adding ability to override api…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ apply plugin: 'signing'
 
 group = "com.pokitdok"
 archivesBaseName = "pokitdok-java"
-version = "0.8"
+version = "0.9"
 sourceCompatibility = 1.6
 targetCompatibility = 1.6
 

--- a/src/main/java/com/pokitdok/ApacheHTTPConnector.java
+++ b/src/main/java/com/pokitdok/ApacheHTTPConnector.java
@@ -1,6 +1,7 @@
 package com.pokitdok;
 
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -17,7 +18,6 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
@@ -33,7 +33,6 @@ public class ApacheHTTPConnector implements PokitDokHTTPConnector {
     private HttpClientBuilder     builder;
     private JSONParser            parser;
     private boolean               failedOnceAlready;
-    private String                apiBase;
     private Map<String, String>   defaultHeaders;
     private String                clientId;
     private String                clientSecret;
@@ -54,7 +53,7 @@ public class ApacheHTTPConnector implements PokitDokHTTPConnector {
         builder = HttpClientBuilder.create();
         builder.useSystemProperties();
 
-        HttpPost request = new HttpPost(PokitDok.DEFAULT_API_BASE + "/oauth2/token");
+        HttpPost request = new HttpPost(PokitDok.getApiBase() + "/oauth2/token");
         List<NameValuePair> urlParameters = new ArrayList<NameValuePair>();
         urlParameters.add(new BasicNameValuePair("grant_type", "client_credentials"));
         request.setEntity(new UrlEncodedFormEntity(urlParameters));
@@ -145,7 +144,17 @@ public class ApacheHTTPConnector implements PokitDokHTTPConnector {
 
     public String put(String url, Map<String, Object> params, Map<String, String> headers, String scope)
     throws IOException, ParseException, UnauthorizedException {
-      HttpPut putRequest = new HttpPut(PokitDok.apiUrl(url, params));
+
+        HttpPut putRequest = new HttpPut(PokitDok.apiUrl(url, null));
+        putRequest.addHeader("Content-Type", "application/json");
+        putRequest.addHeader("Accept", "application/json");
+        StringEntity input = null;
+        try {
+            input = new StringEntity(params.toString());
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+        }
+        putRequest.setEntity(input);
 
       return execute(putRequest, scope, headers);
     }

--- a/src/main/java/com/pokitdok/PokitDok.java
+++ b/src/main/java/com/pokitdok/PokitDok.java
@@ -29,8 +29,18 @@ public class PokitDok {
     private String                clientId;
     private String                clientSecret;
     private String                apiVersion;
+    private static String         apiBase = DEFAULT_API_BASE;
     public static Map<String, String> defaultHeaders;
     private JSONParser            parser;
+
+    public static String getApiBase() {
+        return apiBase == null ? DEFAULT_API_BASE : apiBase;
+    }
+
+    public PokitDok(String clientId, String clientSecret, String apiBase) throws IOException, ParseException {
+        this(clientId, clientSecret, new ApacheHTTPConnector(clientId, clientSecret, getDefaultHeaders()));
+        this.apiBase = apiBase;
+    }
 
     public PokitDok(String clientId, String clientSecret) throws IOException, ParseException {
         this(clientId, clientSecret, new ApacheHTTPConnector(clientId, clientSecret, getDefaultHeaders()));
@@ -55,7 +65,11 @@ public class PokitDok {
     }
 
     public static String apiUrl(String endpoint, Map<String, Object> params) {
-      String uri = DEFAULT_API_BASE + "/api/" + API_VERSION + "/" + endpoint;
+      String uri = getApiBase() + "/api/" + API_VERSION + "/" + endpoint;
+
+      if (null == params) {
+          return uri;
+      }
 
       if ((params != null) && (!params.isEmpty())) {
         try {
@@ -304,6 +318,40 @@ public class PokitDok {
     public Map<String, Object> mpc(String code, Map <String, Object> params)
     throws IOException, ParseException, UnauthorizedException {
         String results = results = connector.get("mpc/" + code, params, defaultHeaders);
+        return (JSONObject) parser.parse(results);
+    }
+
+    /* Identity Endpoints */
+    public Map<String, Object> createIdentity(Map <String, Object> params)
+            throws IOException, ParseException, UnauthorizedException {
+        String results = connector.post("identity/", params, defaultHeaders);
+        return (JSONObject) parser.parse(results);
+    }
+
+    public Map<String, Object> updateIdentity(String uuid, Map <String, Object> params)
+            throws IOException, ParseException, UnauthorizedException {
+        String results = connector.put("identity/" + uuid, params, defaultHeaders);
+        return (JSONObject) parser.parse(results);
+    }
+
+    public Map<String, Object> identity(String uuid)
+            throws IOException, ParseException, UnauthorizedException {
+        return identity(uuid, null);
+    }
+
+    public Map<String, Object> identity(Map <String, Object> params)
+            throws IOException, ParseException, UnauthorizedException {
+        return identity(null, params);
+    }
+
+    /* get particular if uuid. otherwise search */
+    public Map<String, Object> identity(String uuid, Map <String, Object> params)
+            throws IOException, ParseException, UnauthorizedException {
+        String urlString = "identity";
+        if (null != uuid && !uuid.isEmpty()) {
+            urlString += "/" + uuid;
+        }
+        String results = connector.get(urlString, params, defaultHeaders);
         return (JSONObject) parser.parse(results);
     }
 }

--- a/src/main/java/com/pokitdok/PokitDok.java
+++ b/src/main/java/com/pokitdok/PokitDok.java
@@ -19,7 +19,7 @@ import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
 
 public class PokitDok {
-    public static final String VERSION = "0.8";
+    public static final String VERSION = "0.9";
     public static final String API_VERSION = "v4";
     public static final String DEFAULT_API_BASE = "https://platform.pokitdok.com";
     public static final String DEFAULT_SCOPE = "default";

--- a/src/test/java/com/pokitdok/tests/Constants.java
+++ b/src/test/java/com/pokitdok/tests/Constants.java
@@ -9,6 +9,9 @@ public class Constants {
 	public static final String BOOK_APPOINTMENT_JSON 	= "src/test/resources/book_appointment.json";
 	public static final String OPEN_SLOTS_JSON 		= "src/test/resources/open_slots.json";
 	public static final String UPDATE_APPOINTMENT_JSON = "src/test/resources/update_appointment.json";
+	public static final String CREATE_IDENTITY_JSON = "src/test/resources/create_identity.json";
+	public static final String UPDATE_IDENTITY_JSON = "src/test/resources/update_identity.json";
+	public static final String GET_IDENTITY_JSON = "src/test/resources/get_identity.json";
 
 	public static final String BLANK_JSON = "{ \"foo\": \"bar\"}";
 }

--- a/src/test/java/com/pokitdok/tests/PokitDokIntegrationTests.java
+++ b/src/test/java/com/pokitdok/tests/PokitDokIntegrationTests.java
@@ -16,18 +16,27 @@ import static org.mockito.Mockito.*;
 public class PokitDokIntegrationTests {
     private static String CLIENT_ID;
     private static String CLIENT_SECRET;
+    private static String API_BASE;
     private static PokitDok pd;
 
     @BeforeClass
     public static void setup() throws Exception {
         Map<String, String> env = System.getenv();
-        CLIENT_ID = env.get("PD_CLIENT_ID");
-        CLIENT_SECRET = env.get("PD_CLIENT_SECRET");
+        CLIENT_ID = null != CLIENT_ID ? CLIENT_ID : env.get("PD_CLIENT_ID");
+        CLIENT_SECRET = null != CLIENT_SECRET ? CLIENT_SECRET : env.get("PD_CLIENT_SECRET");
         if ((CLIENT_ID == null) || (CLIENT_SECRET == null)) {
             fail("Please provide a PokitDok client ID and secret in the environment variables PD_CLIENT_ID and PD_CLIENT_SECRET.");
         }
 
-        pd = new PokitDok(CLIENT_ID, CLIENT_SECRET);
+        API_BASE = env.get("PD_API_BASE");
+
+        if (null == API_BASE) {
+            pd = new PokitDok(CLIENT_ID, CLIENT_SECRET);
+        } else {
+            pd = new PokitDok(CLIENT_ID, CLIENT_SECRET, API_BASE);
+        }
+
+
     }
 
     @Test
@@ -134,6 +143,52 @@ public class PokitDokIntegrationTests {
         String queryJSON = readEntireFile(Constants.REFERRALS_JSON);
         Map<String, Object> query = (JSONObject) JSONValue.parse(queryJSON);
         Map<String, Object> response = pd.referrals(query);
+
+        assertNotNull(response);
+    }
+
+
+    /* Identity tests. */
+
+    // test post
+    @Test
+    @Category(IntegrationTests.class)
+    public void createIdentityTest() throws Exception {
+        String postJSON = readEntireFile(Constants.CREATE_IDENTITY_JSON);
+        Map<String, Object> post = (JSONObject) JSONValue.parse(postJSON);
+        Map<String, Object> response = pd.createIdentity(post);
+
+        assertNotNull(response);
+    }
+
+    //test update
+    @Test
+    @Category(IntegrationTests.class)
+    public void updateIdentityTest() throws Exception {
+        String updateJSON = readEntireFile(Constants.UPDATE_IDENTITY_JSON);
+        Map<String, Object> update = (JSONObject) JSONValue.parse(updateJSON);
+        Map<String, Object> response = pd.updateIdentity("881bc095-2068-43cb-9783-cce630364122", update);
+
+        assertNotNull(response);
+    }
+
+    //test get uuid
+    @Test
+    @Category(IntegrationTests.class)
+    public void getIdentityUuidTest() throws Exception {
+        Map<String, Object> response = pd.identity("881bc095-2068-43cb-9783-cce630364122");
+
+        assertNotNull(response);
+    }
+
+    //test get params
+    @Test
+    @Category(IntegrationTests.class)
+    public void getIdentityParamsTest() throws Exception {
+        String getJSON = readEntireFile(Constants.GET_IDENTITY_JSON);
+        Map<String, Object> get = (JSONObject) JSONValue.parse(getJSON);
+
+        Map<String, Object> response = pd.identity(get);
 
         assertNotNull(response);
     }

--- a/src/test/java/com/pokitdok/tests/PokitDokUnitTests.java
+++ b/src/test/java/com/pokitdok/tests/PokitDokUnitTests.java
@@ -25,6 +25,7 @@ public class PokitDokUnitTests {
 		mockConnector = mock(PokitDokHTTPConnector.class);
 		when(mockConnector.get(anyString(), anyMap(), anyMap())).thenReturn(Constants.BLANK_JSON);
 		when(mockConnector.post(anyString(), anyMap(), anyMap())).thenReturn(Constants.BLANK_JSON);
+		when(mockConnector.put(anyString(), anyMap(), anyMap())).thenReturn(Constants.BLANK_JSON);
 
 		client = new PokitDok("client_id", "client_secret", mockConnector);
 	}
@@ -235,6 +236,56 @@ public class PokitDokUnitTests {
 		Map response = client.providers(query);
 
 		verify(mockConnector).get(eq("providers"), eq(query), anyMap());
+		assertNotNull(response);
+	}
+
+
+	/* Identity tests. */
+
+	// test post
+	@Test
+	@Category(UnitTests.class)
+	public void createIdentityTest() throws Exception {
+		String postJSON = readEntireFile(Constants.CREATE_IDENTITY_JSON);
+		Map<String, Object> post = (JSONObject) JSONValue.parse(postJSON);
+		Map<String, Object> response = client.createIdentity(post);
+
+		verify(mockConnector).post(eq("identity/"), eq(post), anyMap());
+		assertNotNull(response);
+	}
+
+	//test update
+	@Test
+	@Category(UnitTests.class)
+	public void updateIdentityTest() throws Exception {
+		String updateJSON = readEntireFile(Constants.UPDATE_IDENTITY_JSON);
+		Map<String, Object> update = (JSONObject) JSONValue.parse(updateJSON);
+		Map<String, Object> response = client.updateIdentity("881bc095-2068-43cb-9783-cce630364122", update);
+
+		verify(mockConnector).put(eq("identity/881bc095-2068-43cb-9783-cce630364122"), eq(update), anyMap());
+		assertNotNull(response);
+	}
+
+	//test get uuid
+	@Test
+	@Category(UnitTests.class)
+	public void getIdentityUuidTest() throws Exception {
+		Map<String, Object> response = client.identity("881bc095-2068-43cb-9783-cce630364122", new HashMap<String, Object>());
+
+		verify(mockConnector).get(eq("identity/881bc095-2068-43cb-9783-cce630364122"), eq(new HashMap<String, Object>()), anyMap());
+		assertNotNull(response);
+	}
+
+	//test get params
+	@Test
+	@Category(UnitTests.class)
+	public void getIdentityParamsTest() throws Exception {
+		String getJSON = readEntireFile(Constants.GET_IDENTITY_JSON);
+		Map<String, Object> get = (JSONObject) JSONValue.parse(getJSON);
+
+		Map<String, Object> response = client.identity("", get);
+
+		verify(mockConnector).get(eq("identity"), eq(get), anyMap());
 		assertNotNull(response);
 	}
 

--- a/src/test/resources/create_identity.json
+++ b/src/test/resources/create_identity.json
@@ -1,0 +1,25 @@
+{
+  "prefix": "Ms",
+  "first_name": "Peg",
+  "last_name": "PokitDok",
+  "gender": "female",
+  "birth_date": "1991-05-19",
+  "email": "peggy@pokitdok.com",
+  "address": {
+    "address_lines": ["1542 Anywhere Avenue"],
+    "city": "Charleston",
+    "state": "SC",
+    "zipcode": "29407"
+  },
+  "identifiers": [
+    {
+      "location": [
+        -80.0406,
+        32.8986
+      ],
+      "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+      "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+      "value": "W90100-IG-88"
+    }
+  ]
+}

--- a/src/test/resources/get_identity.json
+++ b/src/test/resources/get_identity.json
@@ -1,0 +1,6 @@
+{
+  "first_name": "Peg",
+  "last_name": "PokitDok",
+  "gender": "female",
+  "prefix": "Ms."
+}

--- a/src/test/resources/update_identity.json
+++ b/src/test/resources/update_identity.json
@@ -1,0 +1,25 @@
+{
+  "prefix": "Ms",
+  "first_name": "Peg",
+  "last_name": "PokitDok",
+  "gender": "female",
+  "birth_date": "1991-05-19",
+  "email": "peggy@pokitdok.com",
+  "address": {
+    "address_lines": ["1542 Anywhere Avenue"],
+    "city": "Charleston",
+    "state": "SC",
+    "zipcode": "29407"
+  },
+  "identifiers": [
+    {
+      "location": [
+        -80.0406,
+        32.8986
+      ],
+      "provider_uuid": "74850f65-6bb7-48e1-9fcb-bc98c8dda2ba",
+      "system_uuid": "967d207f-b024-41cc-8cac-89575a1f6fef",
+      "value": "W90100-IG-88"
+    }
+  ]
+}


### PR DESCRIPTION
--> Adding identity endpoints to the java client.
--> Also, note the ApacheHttpConnector.put -->  I added the 'setEntity stuff'. This was necessary because the PokitDok.apiUrl did not take into account a nested Json object as the value, ie:
         for(String key: params.keySet()) {
            uriWithParams.addParameter(key, (String) params.get(key));
          }
...when doing a put w/ nested Json with identifiers and such it would bomb.
--> Also, I added the ability to override the baseApi so I could more effectively run local unit/integration tests to make sure the identity methods were working againts ohp/graph code.

...... can now run (in one line):
PD_CLIENT_ID=blah PD_CLIENT_SECRET=blah PD_API_BASE=http://localhost:5002 gradle test integrationTest